### PR TITLE
feat: use new version pkg

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -16,6 +16,9 @@ jobs:
     steps:
     - name: clone
       uses: actions/checkout@v2
+      with:
+        # ensures we fetch tag history for the repository
+        fetch-depth: 0
 
     - name: setup
       run: |

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -17,15 +17,17 @@ jobs:
     - name: clone
       uses: actions/checkout@v2
 
+    - name: setup
+      run: |
+        # setup git tag in Actions environment
+        echo "GITHUB_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+
     - name: build
       env:
         GOOS: linux
         CGO_ENABLED: '0'
       run: |
-        go build -a \
-          -ldflags '-s -w -extldflags "-static"' \
-          -o release/vela-git \
-          github.com/go-vela/vela-git/cmd/vela-git
+        make build-static-ci
 
     - name: publish
       uses: elgohr/Publish-Docker-Github-Action@master

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
     - name: clone
       uses: actions/checkout@v2
+      with:
+        # ensures we fetch tag history for the repository
+        fetch-depth: 0
 
     - name: build
       env:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,10 +21,7 @@ jobs:
         GOOS: linux
         CGO_ENABLED: '0'
       run: |
-        go build -a \
-          -ldflags '-s -w -extldflags "-static"' \
-          -o release/vela-git \
-          github.com/go-vela/vela-git/cmd/vela-git
+        make build-static-ci
 
     - name: publish
       uses: elgohr/Publish-Docker-Github-Action@master

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,30 @@
 #
 # Use of this source code is governed by the LICENSE file in this repository.
 
+# capture the current date we build the application from
+BUILD_DATE = $(shell date +%Y-%m-%dT%H:%M:%SZ)
+
+# check if a git commit sha is already set
+ifndef GITHUB_SHA
+	# capture the current git commit sha we build the application from
+	GITHUB_SHA = $(shell git rev-parse HEAD)
+endif
+
+# check if a git tag is already set
+ifndef GITHUB_TAG
+	# capture the current git tag we build the application from
+	GITHUB_TAG = $(shell git describe --tag --abbrev=0)
+endif
+
+# check if a go version is already set
+ifndef GOLANG_VERSION
+	# capture the current go version we build the application from
+	GOLANG_VERSION = $(shell go version | awk '{ print $$3 }')
+endif
+
+# create a list of linker flags for building the golang application
+LD_FLAGS = -X github.com/go-vela/vela-git/version.Commit=${GITHUB_SHA} -X github.com/go-vela/vela-git/version.Date=${BUILD_DATE} -X github.com/go-vela/vela-git/version.Go=${GOLANG_VERSION} -X github.com/go-vela/vela-git/version.Tag=${GITHUB_TAG}
+
 # The `clean` target is intended to clean the workspace
 # and prepare the local changes for submission.
 #
@@ -90,6 +114,7 @@ build:
 	@echo "### Building release/vela-git binary"
 	GOOS=linux CGO_ENABLED=0 \
 		go build -a \
+		-ldflags '${LD_FLAGS}' \
 		-o release/vela-git \
 		github.com/go-vela/vela-git/cmd/vela-git
 
@@ -103,7 +128,21 @@ build-static:
 	@echo "### Building static release/vela-git binary"
 	GOOS=linux CGO_ENABLED=0 \
 		go build -a \
-		-ldflags '-s -w -extldflags "-static"' \
+		-ldflags '-s -w -extldflags "-static" ${LD_FLAGS}' \
+		-o release/vela-git \
+		github.com/go-vela/vela-git/cmd/vela-git
+
+# The `build-static-ci` target is intended to compile
+# the Go source code into a statically linked binary
+# when used within a CI environment.
+#
+# Usage: `make build-static-ci`
+.PHONY: build-static-ci
+build-static-ci:
+	@echo
+	@echo "### Building CI static release/vela-git binary"
+	@go build -a \
+		-ldflags '-s -w -extldflags "-static" ${LD_FLAGS}' \
 		-o release/vela-git \
 		github.com/go-vela/vela-git/cmd/vela-git
 

--- a/cmd/vela-git/main.go
+++ b/cmd/vela-git/main.go
@@ -5,8 +5,12 @@
 package main
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"time"
+
+	"github.com/go-vela/vela-git/version"
 
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -32,8 +36,9 @@ func main() {
 
 	// Plugin Metadata
 
-	app.Compiled = time.Now()
 	app.Action = run
+	app.Compiled = time.Now()
+	app.Version = version.New().Semantic()
 
 	// Plugin Flags
 
@@ -121,6 +126,15 @@ func main() {
 
 // run executes the plugin based off the configuration provided.
 func run(c *cli.Context) error {
+	// capture the version information as pretty JSON
+	v, err := json.MarshalIndent(version.New(), "", "  ")
+	if err != nil {
+		return err
+	}
+
+	// output the version information to stdout
+	fmt.Fprintf(os.Stdout, "%s\n", string(v))
+
 	// set the log level for the plugin
 	switch c.String("log.level") {
 	case "t", "trace", "Trace", "TRACE":
@@ -170,7 +184,7 @@ func run(c *cli.Context) error {
 	}
 
 	// validate the plugin
-	err := p.Validate()
+	err = p.Validate()
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
 	github.com/go-vela/types v0.6.1-0.20201019123446-226d0cc72538
-	github.com/go-vela/vela-docker v0.3.0 // indirect
 	github.com/joho/godotenv v1.3.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/afero v1.3.1

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,10 @@ module github.com/go-vela/vela-git
 go 1.13
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/go-vela/types v0.6.1-0.20201019123446-226d0cc72538
+	github.com/go-vela/vela-docker v0.3.0 // indirect
 	github.com/joho/godotenv v1.3.0
 	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/afero v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -12,12 +12,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/go-vela/types v0.6.0 h1:82/+Y3EGnnr37HeaJ5qhz/PGMvLkJfYvblEw1kFwxb4=
 github.com/go-vela/types v0.6.1-0.20201019123446-226d0cc72538 h1:ck0Ylos/ExUCluEqQgVxKrTZ21nsup0VZT31sWqTU4Y=
 github.com/go-vela/types v0.6.1-0.20201019123446-226d0cc72538/go.mod h1:6r6mWIPrTANBpHwAFAIii64VKtzlAzVagbm/wX5bHHk=
-github.com/go-vela/vela-artifactory v0.3.0 h1:+Xmede6Ug5zQCShn7w3qwHArDzWTpzDRtf0OosnjHpc=
-github.com/go-vela/vela-docker v0.3.0 h1:gmJ0JSoFZG+ku+SPLhbdDxTz21afXdoBrEsn3EWf964=
-github.com/go-vela/vela-docker v0.3.0/go.mod h1:Y8l2OmPpwijI99RnX+JYunq1YrNWsQQ6v/lKDCz8s5I=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
+github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3 h1:q+sMKdA6L8LyGVudTkpGoC73h6ak2iWSPFiFo/pFOU8=
+github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3/go.mod h1:5hCug3EZaHXU3FdCA3gJm0YTNi+V+ooA2qNTiVpky4A=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng4PGlyM=
@@ -6,11 +10,20 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
+github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/go-vela/types v0.6.0 h1:82/+Y3EGnnr37HeaJ5qhz/PGMvLkJfYvblEw1kFwxb4=
+github.com/go-vela/types v0.6.1-0.20201019123446-226d0cc72538 h1:ck0Ylos/ExUCluEqQgVxKrTZ21nsup0VZT31sWqTU4Y=
+github.com/go-vela/types v0.6.1-0.20201019123446-226d0cc72538/go.mod h1:6r6mWIPrTANBpHwAFAIii64VKtzlAzVagbm/wX5bHHk=
+github.com/go-vela/vela-artifactory v0.3.0 h1:+Xmede6Ug5zQCShn7w3qwHArDzWTpzDRtf0OosnjHpc=
+github.com/go-vela/vela-docker v0.3.0 h1:gmJ0JSoFZG+ku+SPLhbdDxTz21afXdoBrEsn3EWf964=
+github.com/go-vela/vela-docker v0.3.0/go.mod h1:Y8l2OmPpwijI99RnX+JYunq1YrNWsQQ6v/lKDCz8s5I=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3 h1:CE8S1cTafDpPvMhIxNJKvHsGVBgn1xWYf1NbHQhywc8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
+github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -48,3 +61,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
+gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package version
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/Masterminds/semver"
+
+	"github.com/go-vela/types/version"
+)
+
+var (
+	// Arch represents the architecture information for the package.
+	Arch = runtime.GOARCH
+	// Commit represents the git commit information for the package.
+	Commit string
+	// Compiler represents the compiler information for the package.
+	Compiler = runtime.Compiler
+	// Date represents the build date information for the package.
+	Date string
+	// Go represents the golang version information for the package.
+	Go string
+	// OS represents the operating system information for the package.
+	OS = runtime.GOOS
+	// Tag represents the git tag information for the package.
+	Tag string
+)
+
+// New creates a new version object for Vela that is used throughout the application.
+func New() *version.Version {
+	v, err := semver.NewVersion(Tag)
+	if err != nil {
+		fmt.Println(fmt.Errorf("unable to parse semantic version for %s: %v", Tag, err))
+	}
+
+	return &version.Version{
+		Canonical:  Tag,
+		Major:      v.Major(),
+		Minor:      v.Minor(),
+		Patch:      v.Patch(),
+		PreRelease: v.Prerelease(),
+		Metadata: version.Metadata{
+			Architecture:    Arch,
+			BuildDate:       Date,
+			Compiler:        Compiler,
+			GitCommit:       Commit,
+			GoVersion:       Go,
+			OperatingSystem: OS,
+		},
+	}
+}


### PR DESCRIPTION
Dependent on https://github.com/go-vela/types/pull/112

Updating to the new `go-vela/types/version` package to improve the information provided surrounding the application.

When I run `make run` locally, here is the output:

```json
{
  "canonical": "v0.4.0",
  "major": 0,
  "minor": 4,
  "patch": 0,
  "metadata": {
    "architecture": "amd64",
    "build_date": "2020-10-19T14:59:46Z",
    "compiler": "gc",
    "git_commit": "57df9f060b8f5c2f9e69d3f524eafc9d8082dd33",
    "go_version": "go1.15.2",
    "operating_system": "linux"
  }
}
<more logs>
```

**NOTE: This also updates the GitHub Actions pipelines to use our `make` commands for building the binary.**