### PR TITLE
feat(fetch): enable depth parameter

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -137,6 +137,7 @@ The following parameters are used to configure the image:
 | `sha`        | SHA-1 hash generated for commit   | `true`   | **set by Vela**     | `PARAMETER_SHA`<br>`GIT_SHA`<br>`VELA_BUILD_COMMIT`             |
 | `submodules` | enables fetching of submodules    | `false`  | `false`             | `PARAMETER_SUBMODULES`<br>`GIT_SUBMODULES`                      |
 | `tags`       | enables fetching of tags          | `false`  | `false`             | `PARAMETER_TAGS`<br>`GIT_TAGS`                                  |
+| `depth`       | enables fetching with a specific depth          | `false`  | Not set             | `PARAMETER_DEPTH`<br>`GIT_DEPTH`                                  |
 
 ## Template
 

--- a/cmd/vela-git/build.go
+++ b/cmd/vela-git/build.go
@@ -18,6 +18,8 @@ type Build struct {
 	Ref string
 	// SHA-1 hash generated for commit
 	Sha string
+	// depth at which to fetch with
+	Depth string
 }
 
 // Validate verifies the Build is properly configured.

--- a/cmd/vela-git/command.go
+++ b/cmd/vela-git/command.go
@@ -32,30 +32,46 @@ func execCmd(e *exec.Cmd) error {
 // fetchTagsCmd is a helper function to
 // download all objects, including tags,
 // from the ref for a git repo.
-func fetchTagsCmd(ref string) *exec.Cmd {
+func fetchTagsCmd(ref string, depth string) *exec.Cmd {
 	logrus.Trace("returning fetchTagsCmd")
 
-	return exec.Command(
-		"git",
+	args := []string{
 		"fetch",
 		"--tags",
 		"origin",
 		ref,
+	}
+
+	if depth != "" {
+		args = append(args, []string{"--depth", depth}...)
+	}
+
+	return exec.Command(
+		"git",
+		args...,
 	)
 }
 
 // fetchNoTagsCmd is a helper function to
 // download all objects, excluding tags,
 // from the ref for a git repo.
-func fetchNoTagsCmd(ref string) *exec.Cmd {
+func fetchNoTagsCmd(ref string, depth string) *exec.Cmd {
 	logrus.Trace("returning fetchNoTagsCmd")
 
-	return exec.Command(
-		"git",
+	args := []string{
 		"fetch",
 		"--no-tags",
 		"origin",
 		ref,
+	}
+
+	if depth != "" {
+		args = append(args, []string{"--depth", depth}...)
+	}
+
+	return exec.Command(
+		"git",
+		args...,
 	)
 }
 

--- a/cmd/vela-git/command_test.go
+++ b/cmd/vela-git/command_test.go
@@ -28,9 +28,11 @@ func TestGit_fetchTagsCmd(t *testing.T) {
 		"--tags",
 		"origin",
 		"refs/heads/master",
+		"--depth",
+		"10",
 	)
 
-	got := fetchTagsCmd("refs/heads/master", "")
+	got := fetchTagsCmd("refs/heads/master", "10")
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("fetchTagsCmd is %v, want %v", got, want)

--- a/cmd/vela-git/command_test.go
+++ b/cmd/vela-git/command_test.go
@@ -30,7 +30,7 @@ func TestGit_fetchTagsCmd(t *testing.T) {
 		"refs/heads/master",
 	)
 
-	got := fetchTagsCmd("refs/heads/master")
+	got := fetchTagsCmd("refs/heads/master", "")
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("fetchTagsCmd is %v, want %v", got, want)
@@ -45,9 +45,11 @@ func TestGit_fetchNoTagsCmd(t *testing.T) {
 		"--no-tags",
 		"origin",
 		"refs/heads/master",
+		"--depth",
+		"10",
 	)
 
-	got := fetchNoTagsCmd("refs/heads/master")
+	got := fetchNoTagsCmd("refs/heads/master", "10")
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("fetchNoTagsCmd is %v, want %v", got, want)

--- a/cmd/vela-git/main.go
+++ b/cmd/vela-git/main.go
@@ -73,6 +73,12 @@ func main() {
 			Usage:    "commit reference to clone from the repo",
 			Value:    "refs/heads/master",
 		},
+		&cli.StringFlag{
+			EnvVars:  []string{"PARAMETER_DEPTH", "GIT_DEPTH"},
+			FilePath: "/vela/parameters/git/depth,/vela/secrets/git/depth",
+			Name:     "build.depth",
+			Usage:    "enables fetching the repository with the specified depth",
+		},
 
 		// Netrc Flags
 
@@ -165,9 +171,10 @@ func run(c *cli.Context) error {
 	p := &Plugin{
 		// build configuration
 		Build: &Build{
-			Path: c.String("build.path"),
-			Ref:  c.String("build.ref"),
-			Sha:  c.String("build.sha"),
+			Path:  c.String("build.path"),
+			Ref:   c.String("build.ref"),
+			Sha:   c.String("build.sha"),
+			Depth: c.String("build.depth"),
 		},
 		// netrc configuration
 		Netrc: &Netrc{

--- a/cmd/vela-git/plugin.go
+++ b/cmd/vela-git/plugin.go
@@ -70,13 +70,13 @@ func (p *Plugin) Exec() error {
 	// check if repo tags are enabled
 	if p.Repo.Tags {
 		// fetch repo state with tags
-		err = execCmd(fetchTagsCmd(p.Build.Ref))
+		err = execCmd(fetchTagsCmd(p.Build.Ref, p.Build.Depth))
 		if err != nil {
 			return err
 		}
 	} else {
 		// fetch repo state without tags
-		err = execCmd(fetchNoTagsCmd(p.Build.Ref))
+		err = execCmd(fetchNoTagsCmd(p.Build.Ref, p.Build.Depth))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
closes https://github.com/go-vela/community/issues/57

I was initially planning to utilize this configuration option to tell the initial `clone` step within the `.vela.yml` to utilize small depths for large repos. However, it doesn't appear that the current [compiler logic](https://github.com/go-vela/compiler/blob/8e0eb203903168342c5532580a3263053a9b2673/compiler/native/clone.go#L25-L37) handles configuration input for the injected step. Any objections to me opening another PR within the compiler repo to allow the `.vela.yml` to override the default `clone` step?