### PR TITLE
feat: output git version for troubleshooting

### DIFF
--- a/cmd/vela-git/command.go
+++ b/cmd/vela-git/command.go
@@ -140,3 +140,17 @@ func submoduleCmd() *exec.Cmd {
 		"--init",
 	)
 }
+
+// versionCmd is a helper function to output
+// the client version information.
+func versionCmd() *exec.Cmd {
+	logrus.Trace("creating git version command")
+
+	// variable to store flags for command
+	var flags []string
+
+	// add flag for version git command
+	flags = append(flags, "version")
+
+	return exec.Command("git", flags...)
+}

--- a/cmd/vela-git/main.go
+++ b/cmd/vela-git/main.go
@@ -168,7 +168,7 @@ func run(c *cli.Context) error {
 
 	logrus.WithFields(logrus.Fields{
 		"code":     "https://github.com/go-vela/vela-git",
-		"docs":     "https://go-vela.github.io/docs/plugins/registry/git",
+		"docs":     "https://go-vela.github.io/docs/plugins/registry/pipeline/git",
 		"registry": "https://hub.docker.com/r/target/vela-git",
 	}).Info("Vela Git Plugin")
 

--- a/cmd/vela-git/plugin.go
+++ b/cmd/vela-git/plugin.go
@@ -49,6 +49,12 @@ func (p *Plugin) Exec() error {
 		return err
 	}
 
+	// output the git version for troubleshooting
+	err = execCmd(versionCmd())
+	if err != nil {
+		return err
+	}
+
 	// initialize git repo
 	err = execCmd(initCmd())
 	if err != nil {


### PR DESCRIPTION
This invokes the `version` subcommand for the `git` CLI as a part of the plugin output.

To test this, you can checkout this branch and run the following:

```sh
make build; make docker-build; make docker-test
```

This should lead to output that looks like:

```sh
{
  "canonical": "v0.4.0",
  "major": 0,
  "minor": 4,
  "patch": 0,
  "metadata": {
    "architecture": "amd64",
    "build_date": "2021-05-13T11:38:27Z",
    "compiler": "gc",
    "git_commit": "b72c202ab96f4a96124536149ae9dbe317e35f11",
    "go_version": "go1.16.3",
    "operating_system": "linux"
  }
}
time="2021-05-13T16:38:39Z" level=info msg="Vela Git Plugin" code="https://github.com/go-vela/vela-git" docs="https://go-vela.github.io/docs/plugins/registry/pipeline/git" registry="https://hub.docker.com/r/target/vela-git"
$ git version
git version 2.30.2
$ git init
...
```

The important part to pull out of this output is:

```sh
$ git version
git version 2.30.2
```