### PR TITLE
fix(pr target branch): create pr target branch for static analysis tools

### DIFF
--- a/cmd/vela-git/command.go
+++ b/cmd/vela-git/command.go
@@ -131,7 +131,7 @@ func resetCmd(sha string) *exec.Cmd {
 // create a branch reference to the target branch
 // for this pull request.
 func createTargetBranchCmd(prTargetBranch string) *exec.Cmd {
-	logrus.Trace("returning idkCmd")
+	logrus.Trace("returning createTargetBranchCmd")
 
 	return exec.Command(
 		"git",

--- a/cmd/vela-git/command.go
+++ b/cmd/vela-git/command.go
@@ -127,6 +127,21 @@ func resetCmd(sha string) *exec.Cmd {
 	)
 }
 
+// createTargetBranchCmd is a helper function to
+// create a branch reference to the target branch
+// for this pull request.
+func createTargetBranchCmd(prTargetBranch string) *exec.Cmd {
+	logrus.Trace("returning idkCmd")
+
+	return exec.Command(
+		"git",
+		"branch",
+		"-f",
+		prTargetBranch,
+		"origin/"+prTargetBranch,
+	)
+}
+
 // submoduleCmd is a helper function to
 // update the registered submodules to
 // the expected states for a git repo.

--- a/cmd/vela-git/command_test.go
+++ b/cmd/vela-git/command_test.go
@@ -120,6 +120,23 @@ func TestGit_resetCmd(t *testing.T) {
 	}
 }
 
+func TestGit_createTargetBranchCmd(t *testing.T) {
+	// setup types
+	want := exec.Command(
+		"git",
+		"branch",
+		"-f",
+		"main",
+		"origin/main",
+	)
+
+	got := createTargetBranchCmd("main")
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("createTargetBranchCmd is %v, want %v", got, want)
+	}
+}
+
 func TestGit_submoduleCmd(t *testing.T) {
 	// setup types
 	want := exec.Command(

--- a/cmd/vela-git/main.go
+++ b/cmd/vela-git/main.go
@@ -125,7 +125,7 @@ func main() {
 			Usage:    "the remote (clone URL) for the repo being cloned",
 		},
 		&cli.StringFlag{
-			EnvVars: []string{"VELA_PULL_REQUEST_TARGET"},
+			EnvVars: []string{"PARAMETER_PULL_REQUEST_TARGET", "GIT_PULL_REQUEST_TARGET", "VELA_PULL_REQUEST_TARGET"},
 			Name:    "repo.pr_target",
 			Usage:   "the pull request target branch",
 		},

--- a/cmd/vela-git/main.go
+++ b/cmd/vela-git/main.go
@@ -125,9 +125,9 @@ func main() {
 			Usage:    "the remote (clone URL) for the repo being cloned",
 		},
 		&cli.StringFlag{
-			EnvVars:  []string{"VELA_PULL_REQUEST_TARGET"},
-			Name:     "repo.pr_target",
-			Usage:    "the pull request target branch",
+			EnvVars: []string{"VELA_PULL_REQUEST_TARGET"},
+			Name:    "repo.pr_target",
+			Usage:   "the pull request target branch",
 		},
 		&cli.BoolFlag{
 			EnvVars:  []string{"PARAMETER_SUBMODULES", "GIT_SUBMODULES"},
@@ -194,9 +194,9 @@ func run(c *cli.Context) error {
 		},
 		// repo configuration
 		Repo: &Repo{
-			Remote:     c.String("repo.remote"),
-			Submodules: c.Bool("repo.submodules"),
-			Tags:       c.Bool("repo.tags"),
+			Remote:         c.String("repo.remote"),
+			Submodules:     c.Bool("repo.submodules"),
+			Tags:           c.Bool("repo.tags"),
 			PrTargetBranch: c.String("repo.pr_target"),
 		},
 	}

--- a/cmd/vela-git/main.go
+++ b/cmd/vela-git/main.go
@@ -125,9 +125,13 @@ func main() {
 			Usage:    "the remote (clone URL) for the repo being cloned",
 		},
 		&cli.StringFlag{
-			EnvVars: []string{"PARAMETER_PULL_REQUEST_TARGET", "GIT_PULL_REQUEST_TARGET", "VELA_PULL_REQUEST_TARGET"},
-			Name:    "repo.pr_target",
-			Usage:   "the pull request target branch",
+			EnvVars: []string{
+				"PARAMETER_PULL_REQUEST_TARGET",
+				"GIT_PULL_REQUEST_TARGET",
+				"VELA_PULL_REQUEST_TARGET",
+			},
+			Name:  "repo.pr_target",
+			Usage: "the pull request target branch",
 		},
 		&cli.BoolFlag{
 			EnvVars:  []string{"PARAMETER_SUBMODULES", "GIT_SUBMODULES"},

--- a/cmd/vela-git/main.go
+++ b/cmd/vela-git/main.go
@@ -124,6 +124,11 @@ func main() {
 			Name:     "repo.remote",
 			Usage:    "the remote (clone URL) for the repo being cloned",
 		},
+		&cli.StringFlag{
+			EnvVars:  []string{"VELA_PULL_REQUEST_TARGET"},
+			Name:     "repo.pr_target",
+			Usage:    "the pull request target branch",
+		},
 		&cli.BoolFlag{
 			EnvVars:  []string{"PARAMETER_SUBMODULES", "GIT_SUBMODULES"},
 			FilePath: "/vela/parameters/git/submodules,/vela/secrets/git/submodules",
@@ -192,6 +197,7 @@ func run(c *cli.Context) error {
 			Remote:     c.String("repo.remote"),
 			Submodules: c.Bool("repo.submodules"),
 			Tags:       c.Bool("repo.tags"),
+			PrTargetBranch: c.String("repo.pr_target"),
 		},
 	}
 

--- a/cmd/vela-git/plugin.go
+++ b/cmd/vela-git/plugin.go
@@ -88,6 +88,20 @@ func (p *Plugin) Exec() error {
 		}
 	}
 
+	// check if it's a pull request
+	if p.Repo.PrTargetBranch != "" {
+		// fetch target branch state
+		err = execCmd(fetchNoTagsCmd(p.Repo.PrTargetBranch, p.Build.Depth))
+		if err != nil {
+			return err
+		}
+		// create a reference branch to the target branch
+		err = execCmd(createTargetBranchCmd(p.Repo.PrTargetBranch))
+		if err != nil {
+			return err
+		}
+	}
+
 	// hard reset current state to build commit
 	err = execCmd(resetCmd(p.Build.Sha))
 	if err != nil {

--- a/cmd/vela-git/plugin_test.go
+++ b/cmd/vela-git/plugin_test.go
@@ -132,6 +132,53 @@ func TestGit_Plugin_Exec_Tags(t *testing.T) {
 	}
 }
 
+func TestGit_Plugin_Exec_Pull_Request(t *testing.T) {
+	// setup directory
+	dir, err := ioutil.TempDir("/tmp", "vela_git_plugin_")
+	if err != nil {
+		t.Errorf("unable to create temp directory: %v", err)
+	}
+
+	// defer cleanup of directory
+	defer func() {
+		err := os.RemoveAll(dir)
+		if err != nil {
+			logrus.Fatalf("unable to remove temp directory %s: %v", dir, err)
+		}
+	}()
+
+	// setup types
+	p := &Plugin{
+		Build: &Build{
+			Path: dir,
+			Ref:  "refs/heads/test",
+			Sha:  "b3cbd5bbd7e81436d2eee04537ea2b4c0cad4cdf",
+		},
+		Netrc: &Netrc{
+			Machine:  "github.com",
+			Username: "octocat",
+			Password: "superSecretPassword",
+		},
+		Repo: &Repo{
+			Remote:         "https://github.com/octocat/hello-world.git",
+			Submodules:     false,
+			Tags:           false,
+			PrTargetBranch: "master",
+		},
+	}
+
+	err = p.Exec()
+	if err != nil {
+		t.Errorf("Exec returned err: %v", err)
+	}
+
+	masterBranchRef := dir + "/.git/refs/heads/master"
+	_, err = os.Stat(masterBranchRef)
+	if err != nil {
+		t.Errorf("Stat '%s' returned err: %v", masterBranchRef, err)
+	}
+}
+
 func TestGit_Plugin_Validate(t *testing.T) {
 	// setup types
 	p := &Plugin{

--- a/cmd/vela-git/repo.go
+++ b/cmd/vela-git/repo.go
@@ -18,6 +18,8 @@ type Repo struct {
 	Submodules bool
 	// enable fetching of tags
 	Tags bool
+	// target branch for pull request
+	PrTargetBranch string
 }
 
 // Validate verifies the Repo is properly configured.


### PR DESCRIPTION
## Description

Currently the plugin wouldn't create a reference to the target branch for a pull request and solely fetch/checkout a particular commit. This results in some static analysis tools to report no code changes due to it diffing the source and target branch for a pull request. I'd like to fix this issue as to get around this we currently are using a hack step to fetch down the references.

Ref: https://discuss.circleci.com/t/git-checkout-of-a-branch-destroys-local-reference-to-master/23781

Issue: https://git.target.com/vela/feature-requests/issues/175

## Solution

The solution tries to do the bare minimum of work to fix this issue, fetching solely the target branch ref from origin and create the branch locally for reference in static analysis. Would appreciate any and all feedback 🙂 