### PR TITLE
feat: use default branch for init

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -125,19 +125,20 @@ steps:
 
 The following parameters are used to configure the image:
 
-| Name         | Description                       | Required | Default            | Environment Variables                                           |
-| ------------ | --------------------------------- | -------- |--------------------| --------------------------------------------------------------- |
-| `log_level`  | set the log level for the plugin  | `true`   | `info`             | `PARAMETER_LOG_LEVEL`<br>`GIT_LOG_LEVEL`                        |
-| `machine`    | machine name to communicate with  | `true`   | `github.com`       | `PARAMETER_MACHINE`<br>`GIT_MACHINE`<br>`VELA_NETRC_MACHINE`    |
-| `password`   | password for authentication       | `true`   | **set by Vela**    | `PARAMETER_PASSWORD`<br>`GIT_PASSWORD`<br>`VELA_NETRC_PASSWORD` |
-| `username`   | user name for authentication      | `true`   | **set by Vela**    | `PARAMETER_USERNAME`<br>`GIT_USERNAME`<br>`VELA_NETRC_USERNAME` |
-| `path`       | local path to clone repository to | `true`   | **set by Vela**    | `PARAMETER_PATH`<br>`GIT_PATH`<br>`VELA_BUILD_WORKSPACE`        |
-| `ref`        | reference generated for commit    | `true`   | `refs/heads/master` | `PARAMETER_REF`<br>`GIT_REF`<br>`VELA_BUILD_REF`                |
-| `remote`     | full url for cloning repository   | `true`   | **set by Vela**    | `PARAMETER_REMOTE`<br>`GIT_REMOTE`<br>`VELA_REPO_CLONE`         |
-| `sha`        | SHA-1 hash generated for commit   | `true`   | **set by Vela**    | `PARAMETER_SHA`<br>`GIT_SHA`<br>`VELA_BUILD_COMMIT`             |
-| `submodules` | enables fetching of submodules    | `false`  | `false`            | `PARAMETER_SUBMODULES`<br>`GIT_SUBMODULES`                      |
-| `tags`       | enables fetching of tags          | `false`  | `false`            | `PARAMETER_TAGS`<br>`GIT_TAGS`                                  |
-| `depth`       | enables fetching with a specific depth          | `false`  | `100`                | `PARAMETER_DEPTH`<br>`GIT_DEPTH`                                  |
+| Name             | Description                            | Required | Default             | Environment Variables                                                    |
+| ---------------- | -------------------------------------- | -------- |-------------------  | ------------------------------------------------------------------------ |
+| `default_branch` | default branch of the repository       | `true`   | **set by Vela**     | `PARAMETER_DEFAULT_BRANCH`<br>`GIT_DEFAULT_BRANCH`<br>`VELA_REPO_BRANCH` |
+| `log_level`      | set the log level for the plugin       | `true`   | `info`              | `PARAMETER_LOG_LEVEL`<br>`GIT_LOG_LEVEL`                                 |
+| `machine`        | machine name to communicate with       | `true`   | `github.com`        | `PARAMETER_MACHINE`<br>`GIT_MACHINE`<br>`VELA_NETRC_MACHINE`             |
+| `password`       | password for authentication            | `true`   | **set by Vela**     | `PARAMETER_PASSWORD`<br>`GIT_PASSWORD`<br>`VELA_NETRC_PASSWORD`          |
+| `username`       | user name for authentication           | `true`   | **set by Vela**     | `PARAMETER_USERNAME`<br>`GIT_USERNAME`<br>`VELA_NETRC_USERNAME`          |
+| `path`           | local path to clone repository to      | `true`   | **set by Vela**     | `PARAMETER_PATH`<br>`GIT_PATH`<br>`VELA_BUILD_WORKSPACE`                 |
+| `ref`            | reference generated for commit         | `true`   | `refs/heads/master` | `PARAMETER_REF`<br>`GIT_REF`<br>`VELA_BUILD_REF`                         |
+| `remote`         | full url for cloning repository        | `true`   | **set by Vela**     | `PARAMETER_REMOTE`<br>`GIT_REMOTE`<br>`VELA_REPO_CLONE`                  |
+| `sha`            | SHA-1 hash generated for commit        | `true`   | **set by Vela**     | `PARAMETER_SHA`<br>`GIT_SHA`<br>`VELA_BUILD_COMMIT`                      |
+| `submodules`     | enables fetching of submodules         | `false`  | `false`             | `PARAMETER_SUBMODULES`<br>`GIT_SUBMODULES`                               |
+| `tags`           | enables fetching of tags               | `false`  | `false`             | `PARAMETER_TAGS`<br>`GIT_TAGS`                                           |
+| `depth`          | enables fetching with a specific depth | `false`  | `100`               | `PARAMETER_DEPTH`<br>`GIT_DEPTH`                                         |
 
 ## Template
 

--- a/cmd/vela-git/command.go
+++ b/cmd/vela-git/command.go
@@ -95,6 +95,22 @@ func remoteVerboseCmd() *exec.Cmd {
 	)
 }
 
+// defaultBranchCmd is a helper function
+// to set init.defaultBranch in git
+// available to override default branch
+// name when initializing a new repo.
+func defaultBranchCmd(branch string) *exec.Cmd {
+	logrus.Trace("returning defaultBranchCmd")
+
+	return exec.Command(
+		"git",
+		"config",
+		"--global",
+		"init.defaultBranch",
+		branch,
+	)
+}
+
 // resetCmd is a helper function to
 // hard reset the current HEAD to
 // the sha for a git repo.

--- a/cmd/vela-git/command_test.go
+++ b/cmd/vela-git/command_test.go
@@ -72,6 +72,23 @@ func TestGit_initCmd(t *testing.T) {
 	}
 }
 
+func TestGit_defaultBranchCmd(t *testing.T) {
+	// setup types
+	want := exec.Command(
+		"git",
+		"config",
+		"--global",
+		"init.defaultBranch",
+		"main",
+	)
+
+	got := defaultBranchCmd("main")
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("defaultBranchCmd is %v, want %v", got, want)
+	}
+}
+
 func TestGit_remoteAddCmd(t *testing.T) {
 	// setup types
 	want := exec.Command(

--- a/cmd/vela-git/main.go
+++ b/cmd/vela-git/main.go
@@ -119,6 +119,12 @@ func main() {
 		// Repo Flags
 
 		&cli.StringFlag{
+			EnvVars:  []string{"PARAMETER_DEFAULT_BRANCH", "GIT_DEFAULT_BRANCH", "VELA_REPO_BRANCH"},
+			FilePath: "/vela/parameters/git/default_branch,/vela/secrets/git/default_branch",
+			Name:     "repo.default_branch",
+			Usage:    "the default branch of the repo used during git init",
+		},
+		&cli.StringFlag{
 			EnvVars:  []string{"PARAMETER_REMOTE", "GIT_REMOTE", "VELA_REPO_CLONE"},
 			FilePath: "/vela/parameters/git/remote,/vela/secrets/git/remote",
 			Name:     "repo.remote",
@@ -189,9 +195,10 @@ func run(c *cli.Context) error {
 		},
 		// repo configuration
 		Repo: &Repo{
-			Remote:     c.String("repo.remote"),
-			Submodules: c.Bool("repo.submodules"),
-			Tags:       c.Bool("repo.tags"),
+			DefaultBranch: c.String("repo.default_branch"),
+			Remote:        c.String("repo.remote"),
+			Submodules:    c.Bool("repo.submodules"),
+			Tags:          c.Bool("repo.tags"),
 		},
 	}
 

--- a/cmd/vela-git/plugin.go
+++ b/cmd/vela-git/plugin.go
@@ -55,6 +55,12 @@ func (p *Plugin) Exec() error {
 		return err
 	}
 
+	// configure default branch for init
+	err = execCmd(defaultBranchCmd(p.Repo.DefaultBranch))
+	if err != nil {
+		return err
+	}
+
 	// initialize git repo
 	err = execCmd(initCmd())
 	if err != nil {

--- a/cmd/vela-git/plugin_test.go
+++ b/cmd/vela-git/plugin_test.go
@@ -4,28 +4,11 @@
 
 package main
 
-import (
-	"io/ioutil"
-	"os"
-	"testing"
-
-	"github.com/sirupsen/logrus"
-)
+import "testing"
 
 func TestGit_Plugin_Exec(t *testing.T) {
 	// setup directory
-	dir, err := ioutil.TempDir("/tmp", "vela_git_plugin_")
-	if err != nil {
-		t.Errorf("unable to create temp directory: %v", err)
-	}
-
-	// defer cleanup of directory
-	defer func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			logrus.Fatalf("unable to remove temp directory %s: %v", dir, err)
-		}
-	}()
+	dir := t.TempDir()
 
 	// setup types
 	p := &Plugin{
@@ -47,7 +30,7 @@ func TestGit_Plugin_Exec(t *testing.T) {
 		},
 	}
 
-	err = p.Exec()
+	err := p.Exec()
 	if err != nil {
 		t.Errorf("Exec returned err: %v", err)
 	}
@@ -55,18 +38,7 @@ func TestGit_Plugin_Exec(t *testing.T) {
 
 func TestGit_Plugin_Exec_Submodules(t *testing.T) {
 	// setup directory
-	dir, err := ioutil.TempDir("/tmp", "vela_git_plugin_")
-	if err != nil {
-		t.Errorf("unable to create temp directory: %v", err)
-	}
-
-	// defer cleanup of directory
-	defer func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			logrus.Fatalf("unable to remove temp directory %s: %v", dir, err)
-		}
-	}()
+	dir := t.TempDir()
 
 	// setup types
 	p := &Plugin{
@@ -88,7 +60,7 @@ func TestGit_Plugin_Exec_Submodules(t *testing.T) {
 		},
 	}
 
-	err = p.Exec()
+	err := p.Exec()
 	if err != nil {
 		t.Errorf("Exec returned err: %v", err)
 	}
@@ -96,18 +68,7 @@ func TestGit_Plugin_Exec_Submodules(t *testing.T) {
 
 func TestGit_Plugin_Exec_Tags(t *testing.T) {
 	// setup directory
-	dir, err := ioutil.TempDir("/tmp", "vela_git_plugin_")
-	if err != nil {
-		t.Errorf("unable to create temp directory: %v", err)
-	}
-
-	// defer cleanup of directory
-	defer func() {
-		err := os.RemoveAll(dir)
-		if err != nil {
-			logrus.Fatalf("unable to remove temp directory %s: %v", dir, err)
-		}
-	}()
+	dir := t.TempDir()
 
 	// setup types
 	p := &Plugin{
@@ -129,7 +90,7 @@ func TestGit_Plugin_Exec_Tags(t *testing.T) {
 		},
 	}
 
-	err = p.Exec()
+	err := p.Exec()
 	if err != nil {
 		t.Errorf("Exec returned err: %v", err)
 	}

--- a/cmd/vela-git/plugin_test.go
+++ b/cmd/vela-git/plugin_test.go
@@ -40,9 +40,10 @@ func TestGit_Plugin_Exec(t *testing.T) {
 			Password: "superSecretPassword",
 		},
 		Repo: &Repo{
-			Remote:     "https://github.com/octocat/hello-world.git",
-			Submodules: false,
-			Tags:       false,
+			DefaultBranch: "main",
+			Remote:        "https://github.com/octocat/hello-world.git",
+			Submodules:    false,
+			Tags:          false,
 		},
 	}
 
@@ -80,9 +81,10 @@ func TestGit_Plugin_Exec_Submodules(t *testing.T) {
 			Password: "superSecretPassword",
 		},
 		Repo: &Repo{
-			Remote:     "https://github.com/octocat/hello-world.git",
-			Submodules: true,
-			Tags:       false,
+			DefaultBranch: "main",
+			Remote:        "https://github.com/octocat/hello-world.git",
+			Submodules:    true,
+			Tags:          false,
 		},
 	}
 
@@ -120,9 +122,10 @@ func TestGit_Plugin_Exec_Tags(t *testing.T) {
 			Password: "superSecretPassword",
 		},
 		Repo: &Repo{
-			Remote:     "https://github.com/octocat/hello-world.git",
-			Submodules: false,
-			Tags:       true,
+			DefaultBranch: "main",
+			Remote:        "https://github.com/octocat/hello-world.git",
+			Submodules:    false,
+			Tags:          true,
 		},
 	}
 
@@ -146,9 +149,10 @@ func TestGit_Plugin_Validate(t *testing.T) {
 			Password: "superSecretPassword",
 		},
 		Repo: &Repo{
-			Remote:     "https://github.com/octocat/hello-world.git",
-			Submodules: false,
-			Tags:       false,
+			DefaultBranch: "main",
+			Remote:        "https://github.com/octocat/hello-world.git",
+			Submodules:    false,
+			Tags:          false,
 		},
 	}
 
@@ -168,9 +172,10 @@ func TestGit_Plugin_Validate_NoBuild(t *testing.T) {
 			Password: "superSecretPassword",
 		},
 		Repo: &Repo{
-			Remote:     "https://github.com/octocat/hello-world.git",
-			Submodules: false,
-			Tags:       false,
+			DefaultBranch: "main",
+			Remote:        "https://github.com/octocat/hello-world.git",
+			Submodules:    false,
+			Tags:          false,
 		},
 	}
 
@@ -190,9 +195,10 @@ func TestGit_Plugin_Validate_NoNetrc(t *testing.T) {
 		},
 		Netrc: &Netrc{},
 		Repo: &Repo{
-			Remote:     "https://github.com/octocat/hello-world.git",
-			Submodules: false,
-			Tags:       false,
+			DefaultBranch: "main",
+			Remote:        "https://github.com/octocat/hello-world.git",
+			Submodules:    false,
+			Tags:          false,
 		},
 	}
 

--- a/cmd/vela-git/repo.go
+++ b/cmd/vela-git/repo.go
@@ -12,6 +12,8 @@ import (
 
 // Repo represents the plugin configuration for repo information.
 type Repo struct {
+	// default branch of the Repo
+	DefaultBranch string
 	// full remote url for cloning
 	Remote string
 	// enable fetching of submodules
@@ -23,6 +25,11 @@ type Repo struct {
 // Validate verifies the Repo is properly configured.
 func (r *Repo) Validate() error {
 	logrus.Trace("validating repo plugin configuration")
+
+	// verify default branch is provided
+	if len(r.DefaultBranch) == 0 {
+		return fmt.Errorf("no repo default branch provided")
+	}
 
 	// verify remote is provided
 	if len(r.Remote) == 0 {

--- a/cmd/vela-git/repo_test.go
+++ b/cmd/vela-git/repo_test.go
@@ -9,9 +9,10 @@ import "testing"
 func TestGit_Repo_Validate(t *testing.T) {
 	// setup types
 	r := &Repo{
-		Remote:     "https://github.com/octocat/hello-world.git",
-		Submodules: false,
-		Tags:       false,
+		DefaultBranch: "main",
+		Remote:        "https://github.com/octocat/hello-world.git",
+		Submodules:    false,
+		Tags:          false,
 	}
 
 	err := r.Validate()
@@ -23,6 +24,21 @@ func TestGit_Repo_Validate(t *testing.T) {
 func TestGit_Repo_Validate_NoRemote(t *testing.T) {
 	// setup types
 	r := &Repo{
+		DefaultBranch: "main",
+		Submodules:    false,
+		Tags:          false,
+	}
+
+	err := r.Validate()
+	if err == nil {
+		t.Errorf("Validate should have returned err")
+	}
+}
+
+func TestGit_Repo_Validate_NoDefaultBranch(t *testing.T) {
+	// setup types
+	r := &Repo{
+		Remote:     "https://github.com/octocat/hello-world.git",
 		Submodules: false,
 		Tags:       false,
 	}


### PR DESCRIPTION
adding support to configure default branch prior to init. mainly to suppress this message during default clone step:
```
$ git init
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint: 
hint: 	git config --global init.defaultBranch <name>
hint: 
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint: 
hint: 	git branch -m <name>
```

it will by default utilize the value from `VELA_REPO_BRANCH` which is set during creation of the repo in Vela and taken from the source provider directly.

ref: https://github.blog/2020-07-27-highlights-from-git-2-28/#introducing-init-defaultbranch