### PR TITLE
fix!: branch setup for git init

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -125,20 +125,20 @@ steps:
 
 The following parameters are used to configure the image:
 
-| Name             | Description                            | Required | Default             | Environment Variables                                                    |
-| ---------------- | -------------------------------------- | -------- |-------------------  | ------------------------------------------------------------------------ |
-| `default_branch` | default branch of the repository       | `true`   | **set by Vela**     | `PARAMETER_DEFAULT_BRANCH`<br>`GIT_DEFAULT_BRANCH`<br>`VELA_REPO_BRANCH` |
-| `log_level`      | set the log level for the plugin       | `true`   | `info`              | `PARAMETER_LOG_LEVEL`<br>`GIT_LOG_LEVEL`                                 |
-| `machine`        | machine name to communicate with       | `true`   | `github.com`        | `PARAMETER_MACHINE`<br>`GIT_MACHINE`<br>`VELA_NETRC_MACHINE`             |
-| `password`       | password for authentication            | `true`   | **set by Vela**     | `PARAMETER_PASSWORD`<br>`GIT_PASSWORD`<br>`VELA_NETRC_PASSWORD`          |
-| `username`       | user name for authentication           | `true`   | **set by Vela**     | `PARAMETER_USERNAME`<br>`GIT_USERNAME`<br>`VELA_NETRC_USERNAME`          |
-| `path`           | local path to clone repository to      | `true`   | **set by Vela**     | `PARAMETER_PATH`<br>`GIT_PATH`<br>`VELA_BUILD_WORKSPACE`                 |
-| `ref`            | reference generated for commit         | `true`   | `refs/heads/master` | `PARAMETER_REF`<br>`GIT_REF`<br>`VELA_BUILD_REF`                         |
-| `remote`         | full url for cloning repository        | `true`   | **set by Vela**     | `PARAMETER_REMOTE`<br>`GIT_REMOTE`<br>`VELA_REPO_CLONE`                  |
-| `sha`            | SHA-1 hash generated for commit        | `true`   | **set by Vela**     | `PARAMETER_SHA`<br>`GIT_SHA`<br>`VELA_BUILD_COMMIT`                      |
-| `submodules`     | enables fetching of submodules         | `false`  | `false`             | `PARAMETER_SUBMODULES`<br>`GIT_SUBMODULES`                               |
-| `tags`           | enables fetching of tags               | `false`  | `false`             | `PARAMETER_TAGS`<br>`GIT_TAGS`                                           |
-| `depth`          | enables fetching with a specific depth | `false`  | `100`               | `PARAMETER_DEPTH`<br>`GIT_DEPTH`                                         |
+| Name         | Description                             | Required | Default             | Environment Variables                                                                   |
+|--------------|-----------------------------------------| -------- |---------------------|-----------------------------------------------------------------------------------------|
+| `branch`     | initial branch to clone from repository | `true`   | `master`            | `PARAMETER_BRANCH`<br>`GIT_BRANCH`<br>`VELA_PULL_REQUEST_SOURCE`<br>`VELA_BUILD_BRANCH` |
+| `log_level`  | set the log level for the plugin        | `true`   | `info`              | `PARAMETER_LOG_LEVEL`<br>`GIT_LOG_LEVEL`                                                |
+| `machine`    | machine name to communicate with        | `true`   | `github.com`        | `PARAMETER_MACHINE`<br>`GIT_MACHINE`<br>`VELA_NETRC_MACHINE`                            |
+| `password`   | password for authentication             | `true`   | **set by Vela**     | `PARAMETER_PASSWORD`<br>`GIT_PASSWORD`<br>`VELA_NETRC_PASSWORD`                         |
+| `username`   | user name for authentication            | `true`   | **set by Vela**     | `PARAMETER_USERNAME`<br>`GIT_USERNAME`<br>`VELA_NETRC_USERNAME`                         |
+| `path`       | local path to clone repository to       | `true`   | **set by Vela**     | `PARAMETER_PATH`<br>`GIT_PATH`<br>`VELA_BUILD_WORKSPACE`                                |
+| `ref`        | reference generated for commit          | `true`   | `refs/heads/master` | `PARAMETER_REF`<br>`GIT_REF`<br>`VELA_BUILD_REF`                                        |
+| `remote`     | full url for cloning repository         | `true`   | **set by Vela**     | `PARAMETER_REMOTE`<br>`GIT_REMOTE`<br>`VELA_REPO_CLONE`                                 |
+| `sha`        | SHA-1 hash generated for commit         | `true`   | **set by Vela**     | `PARAMETER_SHA`<br>`GIT_SHA`<br>`VELA_BUILD_COMMIT`                                     |
+| `submodules` | enables fetching of submodules          | `false`  | `false`             | `PARAMETER_SUBMODULES`<br>`GIT_SUBMODULES`                                              |
+| `tags`       | enables fetching of tags                | `false`  | `false`             | `PARAMETER_TAGS`<br>`GIT_TAGS`                                                          |
+| `depth`      | enables fetching with a specific depth  | `false`  | `100`               | `PARAMETER_DEPTH`<br>`GIT_DEPTH`                                                        |
 
 ## Template
 

--- a/cmd/vela-git/build.go
+++ b/cmd/vela-git/build.go
@@ -12,6 +12,8 @@ import (
 
 // Build represents the plugin configuration for build information.
 type Build struct {
+	// branch used for git init
+	Branch string
 	// full path to workspace
 	Path string
 	// reference generated for commit
@@ -25,6 +27,11 @@ type Build struct {
 // Validate verifies the Build is properly configured.
 func (b *Build) Validate() error {
 	logrus.Trace("validating build plugin configuration")
+
+	// verify branch is provided
+	if len(b.Branch) == 0 {
+		return fmt.Errorf("no build branch provided")
+	}
 
 	// verify path is provided
 	if len(b.Path) == 0 {

--- a/cmd/vela-git/build_test.go
+++ b/cmd/vela-git/build_test.go
@@ -16,9 +16,10 @@ func TestGit_Build_Validate(t *testing.T) {
 			name:    "success",
 			failure: false,
 			build: &Build{
-				Path: "/home/octocat_hello-world_1",
-				Ref:  "refs/heads/master",
-				Sha:  "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+				Branch: "master",
+				Path:   "/home/octocat_hello-world_1",
+				Ref:    "refs/heads/master",
+				Sha:    "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
 			},
 		},
 		{

--- a/cmd/vela-git/build_test.go
+++ b/cmd/vela-git/build_test.go
@@ -7,54 +7,72 @@ package main
 import "testing"
 
 func TestGit_Build_Validate(t *testing.T) {
-	// setup types
-	b := &Build{
-		Path: "/home/octocat_hello-world_1",
-		Ref:  "refs/heads/master",
-		Sha:  "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+	tests := []struct {
+		name    string
+		failure bool
+		build   *Build
+	}{
+		{
+			name:    "success",
+			failure: false,
+			build: &Build{
+				Path: "/home/octocat_hello-world_1",
+				Ref:  "refs/heads/master",
+				Sha:  "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+			},
+		},
+		{
+			name:    "failure with no branch",
+			failure: true,
+			build: &Build{
+				Path: "/home/octocat_hello-world_1",
+				Ref:  "refs/heads/master",
+				Sha:  "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+			},
+		},
+		{
+			name:    "failure with no path",
+			failure: true,
+			build: &Build{
+				Branch: "master",
+				Ref:    "refs/heads/master",
+				Sha:    "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+			},
+		},
+		{
+			name:    "failure with no ref",
+			failure: true,
+			build: &Build{
+				Branch: "master",
+				Path:   "/home/octocat_hello-world_1",
+				Sha:    "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+			},
+		},
+		{
+			name:    "failure with no sha",
+			failure: true,
+			build: &Build{
+				Branch: "master",
+				Path:   "/home/octocat_hello-world_1",
+				Ref:    "refs/heads/master",
+			},
+		},
 	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.build.Validate()
 
-	err := b.Validate()
-	if err != nil {
-		t.Errorf("Validate returned err: %v", err)
-	}
-}
+			if test.failure {
+				if err == nil {
+					t.Errorf("Validate for %s should have returned err", test.name)
+				}
 
-func TestGit_Build_Validate_NoPath(t *testing.T) {
-	// setup types
-	b := &Build{
-		Ref: "refs/heads/master",
-		Sha: "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
-	}
+				return
+			}
 
-	err := b.Validate()
-	if err == nil {
-		t.Errorf("Validate should have returned err")
-	}
-}
-
-func TestGit_Build_Validate_NoRef(t *testing.T) {
-	// setup types
-	b := &Build{
-		Path: "/home/octocat_hello-world_1",
-		Sha:  "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
-	}
-
-	err := b.Validate()
-	if err == nil {
-		t.Errorf("Validate should have returned err")
-	}
-}
-
-func TestGit_Build_Validate_NoSha(t *testing.T) {
-	// setup types
-	b := &Build{
-		Path: "/home/octocat_hello-world_1",
-		Ref:  "refs/heads/master",
-	}
-
-	err := b.Validate()
-	if err == nil {
-		t.Errorf("Validate should have returned err")
+			if err != nil {
+				t.Errorf("Validate for %s returned err: %v", test.name, err)
+			}
+		})
 	}
 }

--- a/cmd/vela-git/main.go
+++ b/cmd/vela-git/main.go
@@ -68,6 +68,12 @@ func main() {
 		// Build Flags
 
 		&cli.StringFlag{
+			EnvVars:  []string{"PARAMETER_BRANCH", "GIT_BRANCH", "VELA_PULL_REQUEST_SOURCE", "VELA_BUILD_BRANCH"},
+			FilePath: "/vela/parameters/git/branch,/vela/secrets/git/branch",
+			Name:     "build.branch",
+			Usage:    "the repo branch for the build used during git init",
+		},
+		&cli.StringFlag{
 			EnvVars:  []string{"PARAMETER_SHA", "GIT_SHA", "VELA_BUILD_COMMIT"},
 			FilePath: "/vela/parameters/git/sha,/vela/secrets/git/sha",
 			Name:     "build.sha",
@@ -118,12 +124,6 @@ func main() {
 
 		// Repo Flags
 
-		&cli.StringFlag{
-			EnvVars:  []string{"PARAMETER_DEFAULT_BRANCH", "GIT_DEFAULT_BRANCH", "VELA_REPO_BRANCH"},
-			FilePath: "/vela/parameters/git/default_branch,/vela/secrets/git/default_branch",
-			Name:     "repo.default_branch",
-			Usage:    "the default branch of the repo used during git init",
-		},
 		&cli.StringFlag{
 			EnvVars:  []string{"PARAMETER_REMOTE", "GIT_REMOTE", "VELA_REPO_CLONE"},
 			FilePath: "/vela/parameters/git/remote,/vela/secrets/git/remote",
@@ -182,10 +182,11 @@ func run(c *cli.Context) error {
 	p := &Plugin{
 		// build configuration
 		Build: &Build{
-			Path:  c.String("build.path"),
-			Ref:   c.String("build.ref"),
-			Sha:   c.String("build.sha"),
-			Depth: c.String("build.depth"),
+			Branch: c.String("build.branch"),
+			Path:   c.String("build.path"),
+			Ref:    c.String("build.ref"),
+			Sha:    c.String("build.sha"),
+			Depth:  c.String("build.depth"),
 		},
 		// netrc configuration
 		Netrc: &Netrc{
@@ -195,10 +196,9 @@ func run(c *cli.Context) error {
 		},
 		// repo configuration
 		Repo: &Repo{
-			DefaultBranch: c.String("repo.default_branch"),
-			Remote:        c.String("repo.remote"),
-			Submodules:    c.Bool("repo.submodules"),
-			Tags:          c.Bool("repo.tags"),
+			Remote:     c.String("repo.remote"),
+			Submodules: c.Bool("repo.submodules"),
+			Tags:       c.Bool("repo.tags"),
 		},
 	}
 

--- a/cmd/vela-git/main.go
+++ b/cmd/vela-git/main.go
@@ -72,6 +72,7 @@ func main() {
 			FilePath: "/vela/parameters/git/branch,/vela/secrets/git/branch",
 			Name:     "build.branch",
 			Usage:    "the repo branch for the build used during git init",
+			Value:    "master",
 		},
 		&cli.StringFlag{
 			EnvVars:  []string{"PARAMETER_SHA", "GIT_SHA", "VELA_BUILD_COMMIT"},

--- a/cmd/vela-git/plugin.go
+++ b/cmd/vela-git/plugin.go
@@ -56,7 +56,7 @@ func (p *Plugin) Exec() error {
 	}
 
 	// configure default branch for init
-	err = execCmd(defaultBranchCmd(p.Repo.DefaultBranch))
+	err = execCmd(defaultBranchCmd(p.Build.Branch))
 	if err != nil {
 		return err
 	}

--- a/cmd/vela-git/plugin_test.go
+++ b/cmd/vela-git/plugin_test.go
@@ -13,9 +13,10 @@ func TestGit_Plugin_Exec(t *testing.T) {
 	// setup types
 	p := &Plugin{
 		Build: &Build{
-			Path: dir,
-			Ref:  "refs/heads/master",
-			Sha:  "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+			Branch: "master",
+			Path:   dir,
+			Ref:    "refs/heads/master",
+			Sha:    "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
 		},
 		Netrc: &Netrc{
 			Machine:  "github.com",
@@ -23,10 +24,9 @@ func TestGit_Plugin_Exec(t *testing.T) {
 			Password: "superSecretPassword",
 		},
 		Repo: &Repo{
-			DefaultBranch: "main",
-			Remote:        "https://github.com/octocat/hello-world.git",
-			Submodules:    false,
-			Tags:          false,
+			Remote:     "https://github.com/octocat/hello-world.git",
+			Submodules: false,
+			Tags:       false,
 		},
 	}
 
@@ -43,9 +43,10 @@ func TestGit_Plugin_Exec_Submodules(t *testing.T) {
 	// setup types
 	p := &Plugin{
 		Build: &Build{
-			Path: dir,
-			Ref:  "refs/heads/master",
-			Sha:  "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+			Branch: "master",
+			Path:   dir,
+			Ref:    "refs/heads/master",
+			Sha:    "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
 		},
 		Netrc: &Netrc{
 			Machine:  "github.com",
@@ -53,10 +54,9 @@ func TestGit_Plugin_Exec_Submodules(t *testing.T) {
 			Password: "superSecretPassword",
 		},
 		Repo: &Repo{
-			DefaultBranch: "main",
-			Remote:        "https://github.com/octocat/hello-world.git",
-			Submodules:    true,
-			Tags:          false,
+			Remote:     "https://github.com/octocat/hello-world.git",
+			Submodules: true,
+			Tags:       false,
 		},
 	}
 
@@ -73,9 +73,10 @@ func TestGit_Plugin_Exec_Tags(t *testing.T) {
 	// setup types
 	p := &Plugin{
 		Build: &Build{
-			Path: dir,
-			Ref:  "refs/heads/master",
-			Sha:  "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+			Branch: "master",
+			Path:   dir,
+			Ref:    "refs/heads/master",
+			Sha:    "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
 		},
 		Netrc: &Netrc{
 			Machine:  "github.com",
@@ -83,10 +84,9 @@ func TestGit_Plugin_Exec_Tags(t *testing.T) {
 			Password: "superSecretPassword",
 		},
 		Repo: &Repo{
-			DefaultBranch: "main",
-			Remote:        "https://github.com/octocat/hello-world.git",
-			Submodules:    false,
-			Tags:          true,
+			Remote:     "https://github.com/octocat/hello-world.git",
+			Submodules: false,
+			Tags:       true,
 		},
 	}
 
@@ -100,9 +100,10 @@ func TestGit_Plugin_Validate(t *testing.T) {
 	// setup types
 	p := &Plugin{
 		Build: &Build{
-			Path: "/home/octocat_hello-world_1",
-			Ref:  "refs/heads/master",
-			Sha:  "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
+			Branch: "master",
+			Path:   "/home/octocat_hello-world_1",
+			Ref:    "refs/heads/master",
+			Sha:    "7fd1a60b01f91b314f59955a4e4d4e80d8edf11d",
 		},
 		Netrc: &Netrc{
 			Machine:  "github.com",
@@ -110,10 +111,9 @@ func TestGit_Plugin_Validate(t *testing.T) {
 			Password: "superSecretPassword",
 		},
 		Repo: &Repo{
-			DefaultBranch: "main",
-			Remote:        "https://github.com/octocat/hello-world.git",
-			Submodules:    false,
-			Tags:          false,
+			Remote:     "https://github.com/octocat/hello-world.git",
+			Submodules: false,
+			Tags:       false,
 		},
 	}
 
@@ -133,10 +133,9 @@ func TestGit_Plugin_Validate_NoBuild(t *testing.T) {
 			Password: "superSecretPassword",
 		},
 		Repo: &Repo{
-			DefaultBranch: "main",
-			Remote:        "https://github.com/octocat/hello-world.git",
-			Submodules:    false,
-			Tags:          false,
+			Remote:     "https://github.com/octocat/hello-world.git",
+			Submodules: false,
+			Tags:       false,
 		},
 	}
 
@@ -156,10 +155,9 @@ func TestGit_Plugin_Validate_NoNetrc(t *testing.T) {
 		},
 		Netrc: &Netrc{},
 		Repo: &Repo{
-			DefaultBranch: "main",
-			Remote:        "https://github.com/octocat/hello-world.git",
-			Submodules:    false,
-			Tags:          false,
+			Remote:     "https://github.com/octocat/hello-world.git",
+			Submodules: false,
+			Tags:       false,
 		},
 	}
 

--- a/cmd/vela-git/repo.go
+++ b/cmd/vela-git/repo.go
@@ -12,8 +12,6 @@ import (
 
 // Repo represents the plugin configuration for repo information.
 type Repo struct {
-	// default branch of the Repo
-	DefaultBranch string
 	// full remote url for cloning
 	Remote string
 	// enable fetching of submodules
@@ -25,11 +23,6 @@ type Repo struct {
 // Validate verifies the Repo is properly configured.
 func (r *Repo) Validate() error {
 	logrus.Trace("validating repo plugin configuration")
-
-	// verify default branch is provided
-	if len(r.DefaultBranch) == 0 {
-		return fmt.Errorf("no repo default branch provided")
-	}
 
 	// verify remote is provided
 	if len(r.Remote) == 0 {

--- a/cmd/vela-git/repo_test.go
+++ b/cmd/vela-git/repo_test.go
@@ -9,10 +9,9 @@ import "testing"
 func TestGit_Repo_Validate(t *testing.T) {
 	// setup types
 	r := &Repo{
-		DefaultBranch: "main",
-		Remote:        "https://github.com/octocat/hello-world.git",
-		Submodules:    false,
-		Tags:          false,
+		Remote:     "https://github.com/octocat/hello-world.git",
+		Submodules: false,
+		Tags:       false,
 	}
 
 	err := r.Validate()
@@ -24,21 +23,6 @@ func TestGit_Repo_Validate(t *testing.T) {
 func TestGit_Repo_Validate_NoRemote(t *testing.T) {
 	// setup types
 	r := &Repo{
-		DefaultBranch: "main",
-		Submodules:    false,
-		Tags:          false,
-	}
-
-	err := r.Validate()
-	if err == nil {
-		t.Errorf("Validate should have returned err")
-	}
-}
-
-func TestGit_Repo_Validate_NoDefaultBranch(t *testing.T) {
-	// setup types
-	r := &Repo{
-		Remote:     "https://github.com/octocat/hello-world.git",
 		Submodules: false,
 		Tags:       false,
 	}


### PR DESCRIPTION
xref: https://github.com/go-vela/community/issues/816

Based off of https://github.com/go-vela/vela-git/pull/122

This change ensures we set the expected `branch` when invoking `git init`.

* for `pull_request` events, this sets the branch for `git init` from `VELA_PULL_REQUEST_SOURCE`
* for all other events, this sets the branch for `git init` from `VELA_BUILD_BRANCH`

To test this, I set up a repo with a default branch of `main` and a `.vela.yml` that looks like:

```yaml
version: "1"

metadata:
  clone: false

steps:
  - name: clone
    image: vela-git:local # built this image with 'make build-static; make docker-build'

  - name: context
    image: alpine:latest
    commands:
      - apk add git
      - git branch
      - git status
      - printenv | sort
```

Then, I created a new `context` branch which I modified the `README.md` and opened a PR that targets `main`.

Before this change, for both the `pull_request` and `push` events, here's a snippet of output from the `context` step:

```
<other output>
$ git branch
* main
$ git status
On branch main
nothing to commit, working tree clean
```

After this change, here's a snippet of output from the `context` step:

```
<other output>
$ git branch
* context
$ git status
On branch context
nothing to commit, working tree clean
```