### PR TITLE
Adds github-cli to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM alpine:3.19@sha256:c5b1261d6d3e43071626931fc004f70149baeba2c8ec672bd4f27761
 
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
-RUN apk add --update --no-cache git
+RUN apk add --update --no-cache git github-cli
 
 COPY release/vela-git /bin/vela-git
 


### PR DESCRIPTION
This is baby steps toward https://github.com/go-vela/community/issues/975. Getting credentials in place remains an exercise left to the consumer until gh supports .netrc in cli/cli#288.