### PR TITLE
fix(ci): use correct version for action

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -40,7 +40,7 @@ jobs:
         make build-static-ci
 
     - name: publish
-      uses: elgohr/Publish-Docker-Github-Action@eb53b3ec07136a6ebaed78d8135806da64f7c7e2 # v5.0.2
+      uses: elgohr/Publish-Docker-Github-Action@eb53b3ec07136a6ebaed78d8135806da64f7c7e2 # v5
       with:
         name: target/vela-git
         cache: true


### PR DESCRIPTION
accidentally using an invalid version due to copy/paste error

should get rid of this issue:
![image](https://github.com/user-attachments/assets/ac0b637c-5ab3-4f24-8335-cf6aad2adf73)
