### PR TITLE
enhance: add slim version of git plugin

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -9,6 +9,12 @@ A Vela plugin designed for cloning repositories into your workspace.
 
 Internally, the plugin is a wrapper around the [git](https://git-scm.com/) CLI.
 
+The plugin comes in two flavors: `vela-git-slim` and `vela-git`
+
+`vela-git-slim` contains basic packages required to perform basic git operations - ideal for regular clone steps.
+
+`vela-git` contains all of `vela-git-slim` and additional utility packages related to git, such as `git-lfs` and `gh` (GitHub CLI).
+
 ## Documentation
 
 For installation and usage, please [visit our user docs](https://go-vela.github.io/docs).

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -5,7 +5,7 @@ name: prerelease
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 # pipeline to execute
 jobs:
@@ -13,37 +13,47 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: clone
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      with:
-        # ensures we fetch tag history for the repository
-        fetch-depth: 0
+      - name: clone
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          # ensures we fetch tag history for the repository
+          fetch-depth: 0
 
-    - name: install go
-      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
-      with:
-        # use version from go.mod file
-        go-version-file: 'go.mod'
-        cache: true
-        check-latest: true
+      - name: install go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          # use version from go.mod file
+          go-version-file: "go.mod"
+          cache: true
+          check-latest: true
 
-    - name: setup
-      run: |
-        # setup git tag in Actions environment
-        echo "GITHUB_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+      - name: setup
+        run: |
+          # setup git tag in Actions environment
+          echo "GITHUB_TAG=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
 
-    - name: build
-      env:
-        GOOS: linux
-        CGO_ENABLED: '0'
-      run: |
-        make build-static-ci
+      - name: build
+        env:
+          GOOS: linux
+          CGO_ENABLED: "0"
+        run: |
+          make build-static-ci
 
-    - name: publish
-      uses: elgohr/Publish-Docker-Github-Action@eb53b3ec07136a6ebaed78d8135806da64f7c7e2 # v5
-      with:
-        name: target/vela-git
-        cache: true
-        tag_names: true
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: publish
+        uses: elgohr/Publish-Docker-Github-Action@eb53b3ec07136a6ebaed78d8135806da64f7c7e2 # v5
+        with:
+          name: target/vela-git
+          cache: true
+          tag_names: true
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: publish slim
+        uses: elgohr/Publish-Docker-Github-Action@eb53b3ec07136a6ebaed78d8135806da64f7c7e2 # v5
+        with:
+          dockerfile: Dockerfile.slim
+          name: target/vela-git-slim
+          cache: true
+          tag_names: true
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ name: publish
 # trigger on push events with branch main
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 # pipeline to execute
 jobs:
@@ -12,31 +12,40 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: clone
-      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      with:
-        # ensures we fetch tag history for the repository
-        fetch-depth: 0
+      - name: clone
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          # ensures we fetch tag history for the repository
+          fetch-depth: 0
 
-    - name: install go
-      uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
-      with:
-        # use version from go.mod file
-        go-version-file: 'go.mod'
-        cache: true
-        check-latest: true
+      - name: install go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          # use version from go.mod file
+          go-version-file: "go.mod"
+          cache: true
+          check-latest: true
 
-    - name: build
-      env:
-        GOOS: linux
-        CGO_ENABLED: '0'
-      run: |
-        make build-static-ci
+      - name: build
+        env:
+          GOOS: linux
+          CGO_ENABLED: "0"
+        run: |
+          make build-static-ci
 
-    - name: publish
-      uses: elgohr/Publish-Docker-Github-Action@eb53b3ec07136a6ebaed78d8135806da64f7c7e2 # v5
-      with:
-        name: target/vela-git
-        cache: true
-        username: ${{ secrets.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: publish
+        uses: elgohr/Publish-Docker-Github-Action@eb53b3ec07136a6ebaed78d8135806da64f7c7e2 # v5
+        with:
+          name: target/vela-git
+          cache: true
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: publish slim
+        uses: elgohr/Publish-Docker-Github-Action@eb53b3ec07136a6ebaed78d8135806da64f7c7e2 # v5
+        with:
+          dockerfile: Dockerfile.slim
+          name: target/vela-git-slim
+          cache: true
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}

--- a/DOCS.md
+++ b/DOCS.md
@@ -159,7 +159,7 @@ The following parameters are used to configure the image:
 | `depth`      | enables fetching with a specific depth  | `false`  | `100`               | `PARAMETER_DEPTH`<br>`GIT_DEPTH`                                                        |
 | `lfs`[^1]        | enables resolving LFS objects           | `false`  | `false`             | `PARAMETER_LFS`<br>`GIT_LFS`                                                            |
 
-[^1] only functional in the `target/vela-git` plugin.
+[^1]: only functional in the `target/vela-git` plugin.
 
 ## Template
 

--- a/DOCS.md
+++ b/DOCS.md
@@ -6,7 +6,10 @@ This plugin enables you to clone repositories in a Vela pipeline to your build w
 
 Source Code: https://github.com/go-vela/vela-git
 
-Registry: https://hub.docker.com/r/target/vela-git
+Registry:
+
+- https://hub.docker.com/r/target/vela-git-slim
+- https://hub.docker.com/r/target/vela-git
 
 ## Usage
 
@@ -21,7 +24,7 @@ Sample of cloning a repository:
 ```yaml
 steps:
   - name: clone_vela-git-test
-    image: target/vela-git:latest
+    image: target/vela-git-slim:latest
     pull: always
     parameters:
       path: vela-git-test
@@ -35,7 +38,7 @@ Sample of cloning a repository with submodules:
 ```diff
 steps:
   - name: clone_vela-git-test
-    image: target/vela-git:latest
+    image: target/vela-git-slim:latest
     pull: always
     parameters:
       path: vela-git-test
@@ -50,7 +53,7 @@ Sample of cloning a repository with tags:
 ```diff
 steps:
   - name: clone_vela-git-test
-    image: target/vela-git:latest
+    image: target/vela-git-slim:latest
     pull: always
     parameters:
       path: vela-git-test
@@ -60,7 +63,7 @@ steps:
 +     tags: true
 ```
 
-Sample of cloning a repository and resolving LFS objects:
+Sample of cloning a repository and resolving LFS objects with the `vela-git` plugin:
 
 ```diff
 steps:
@@ -86,7 +89,7 @@ Users can use [Vela internal secrets](https://go-vela.github.io/docs/tour/secret
 ```diff
 steps:
   - name: clone_vela-git-test
-    image: target/vela-git:latest
+    image: target/vela-git-slim:latest
     pull: always
 +   secrets: [ git_username, git_password ]
     parameters:
@@ -117,7 +120,7 @@ Users can use [Vela external secrets](https://go-vela.github.io/docs/concepts/pi
 ```diff
 steps:
   - name: clone_vela-git-test
-    image: target/vela-git:latest
+    image: target/vela-git-slim:latest
     pull: always
     parameters:
 -     username: octocat
@@ -154,7 +157,9 @@ The following parameters are used to configure the image:
 | `submodules` | enables fetching of submodules          | `false`  | `false`             | `PARAMETER_SUBMODULES`<br>`GIT_SUBMODULES`                                              |
 | `tags`       | enables fetching of tags                | `false`  | `false`             | `PARAMETER_TAGS`<br>`GIT_TAGS`                                                          |
 | `depth`      | enables fetching with a specific depth  | `false`  | `100`               | `PARAMETER_DEPTH`<br>`GIT_DEPTH`                                                        |
-| `lfs`        | enables resolving LFS objects           | `false`  | `false`             | `PARAMETER_LFS`<br>`GIT_LFS`                                                            |
+| `lfs`[^1]        | enables resolving LFS objects           | `false`  | `false`             | `PARAMETER_LFS`<br>`GIT_LFS`                                                            |
+
+[^1] only functional in the `target/vela-git` plugin.
 
 ## Template
 
@@ -167,7 +172,7 @@ You can start troubleshooting this plugin by tuning the level of logs being disp
 ```diff
 steps:
   - name: clone_vela-git-test
-    image: target/vela-git:latest
+    image: target/vela-git-slim:latest
     pull: always
     parameters:
 +     log_level: trace

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+
+######################################################################
+##    docker build --no-cache --target certs -t vela-git:certs .    ##
+######################################################################
+
+FROM alpine:3.20.2@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5 as certs
+
+RUN apk add --update --no-cache ca-certificates
+
+#######################################################
+##    docker build --no-cache -t vela-git:local .    ##
+#######################################################
+
+FROM alpine:3.20.2@sha256:0a4eaa0eecf5f8c050e5bba433f58c052be7587ee8af3e8b3910ef9ab5fbe9f5
+
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+RUN apk add --update --no-cache git
+
+COPY release/vela-git /bin/vela-git
+
+ENTRYPOINT [ "/bin/vela-git" ]


### PR DESCRIPTION
in order to keep the base git plugin as lightweight as possible, we are splitting the plugin into two versions: `vela-git` and `vela-git-slim`. 

`vela-git` will contain additional "helper" packages. at this point, that is `gh` and `git-lfs`, but there is potential it might grow further. 

the `-slim` variant will only contain `git` - the bare minimum needed for regular git operations required for most "clone" steps. this will also be the default plugin for the go-vela/server and go-vela/cli modules (additional PRs will follow).

here's an incremental breakdown of size differences:

| image | size |
| ----- | ---- |
| vela-git | 30.3MB |
| vela-git + github-cli | 82.9MB |
| vela-git + github-cli + git-lfs | 90.2MB |

when compressed, you are looking at roughly:

| image | size |
| ----- | ---- |
| vela-git-slim (new with this PR) | 10.6MB |
| vela-git (includes github-cli + git-lfs) | 29.4MB |